### PR TITLE
Make `SyntaxError` display the message when printed

### DIFF
--- a/lib/message_format/parser.rb
+++ b/lib/message_format/parser.rb
@@ -360,7 +360,6 @@ module MessageFormat
     #
     class SyntaxError < StandardError
 
-      attr_reader :message
       attr_reader :expected
       attr_reader :found
       attr_reader :offset
@@ -368,7 +367,7 @@ module MessageFormat
       attr_reader :column
 
       def initialize (message, expected, found, offset, line, column)
-        @message = message
+        super(message)
         @expected = expected
         @found = found
         @offset = offset


### PR DESCRIPTION
This seems to be the way to make ruby errors look best. I tested it like this:

``` ruby
$ cat /tmp/a.rb
class A < StandardError
  def initialize(a)
    @a = a
  end
end

class B < StandardError
  attr_reader :message
  def initialize(message)
    @message = message
  end
end

class C < StandardError
  def initialize(message)
    super(message)
  end
end

puts A.new('foo')
puts A.new('foo').inspect
puts A.new('foo').message
puts B.new('foo')
puts B.new('foo').inspect
puts B.new('foo').message
puts C.new('foo')
puts C.new('foo').inspect
puts C.new('foo').message
$ ruby /tmp/a.rb
A
#<A: A>
A
B
#<B: B>
foo
foo
#<C: foo>
foo
```
