### PR TITLE
Bump to twitter-cldr 4.x

### DIFF
--- a/message_format.gemspec
+++ b/message_format.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "twitter_cldr", "~> 3.1"
+  spec.add_runtime_dependency "twitter_cldr", "~> 4.0"
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
This appears to be API-compatible, and is required for Ruby 2.4 support.