### PR TITLE
Fix a bug with integer number formatting

### DIFF
--- a/lib/message_format/interpreter.rb
+++ b/lib/message_format/interpreter.rb
@@ -84,7 +84,7 @@ module MessageFormat
       lambda do |args|
         number = TwitterCldr::Localized::LocalizedNumber.new(args[id] - offset, locale)
         if style == 'integer'
-          number.to_decimal(:precision => 0).to_s
+          number.to_decimal.to_s(:precision => 0)
         elsif style == 'percent'
           number.to_percent.to_s
         elsif style == 'currency'

--- a/spec/message_format_spec.rb
+++ b/spec/message_format_spec.rb
@@ -47,6 +47,13 @@ describe MessageFormat do
       expect(message).to match(/^0 \: \d\d?\/\d\d?\/\d{2,4} \d\d?\:\d\d [AP]M$/)
     end
 
+    it 'formats integer number' do
+      pattern = '{ n, number, integer }'
+      message = MessageFormat.new(pattern, 'en-US').format({ n: 1234 })
+
+      expect(message).to match('1,234')
+    end
+
     it 'handles plurals' do
       pattern =
         'On {takenDate, date, short} {name} {numPeople, plural, offset:1


### PR DESCRIPTION
I don't know if it has always been like this or the recent bump of `TwitterCLDR` broke it.

```
[dev] main:0> MessageFormat.new("{foo, number, integer}").format({foo: 1234})
ArgumentError: wrong number of arguments (given 1, expected 0)
from /vendor/bundle/ruby/2.6.0/gems/twitter_cldr-5.4.0/lib/twitter_cldr/localized/localized_number.rb:25:in `block (2 levels) in <class:LocalizedNumber>'
``` 
The fix was a simple `s/.to_decimal(precision: 0).to_s/.to_decimal.to_s(precision: 0)/`. See https://github.com/twitter/twitter-cldr-rb/tree/v5.4.0#numbers for reference