### PR TITLE
Add `raise_on_missing_params` option to interpreter

### DIFF
--- a/lib/message_format.rb
+++ b/lib/message_format.rb
@@ -6,11 +6,14 @@ require_relative 'message_format/interpreter'
 module MessageFormat
   class MessageFormat
 
-    def initialize ( pattern, locale=nil )
+    def initialize ( pattern, locale=nil, raise_on_missing_params: false )
       @locale = (locale || TwitterCldr.locale).to_sym
       @format = Interpreter.interpret(
         Parser.parse(pattern),
-        { :locale => @locale }
+        { 
+          :locale => @locale,
+          :raise_on_missing_params => raise_on_missing_params,
+        },
       )
     end
 
@@ -22,15 +25,18 @@ module MessageFormat
 
   class << self
 
-    def new ( pattern, locale=nil )
-      MessageFormat.new(pattern, locale)
+    def new ( pattern, locale=nil, raise_on_missing_params: false )
+      MessageFormat.new(pattern, locale, raise_on_missing_params)
     end
 
-    def format_message ( pattern, args=nil, locale=nil )
+    def format_message ( pattern, args=nil, locale=nil, raise_on_missing_params: false )
       locale ||= TwitterCldr.locale
       Interpreter.interpret(
         Parser.parse(pattern),
-        { :locale => locale.to_sym }
+        { 
+          :locale => locale.to_sym,
+          :raise_on_missing_params => raise_on_missing_params,
+        }
       ).call(args)
     end
 


### PR DESCRIPTION
This option allows the interpreter to keep track of parameters that it tried to access but which turned out to be `nil`, and to raise them in an error when the newly added `raise_on_missing_params` option is set to `true`.