### PR TITLE
Raise error in `parse_arg_id` if a dot if found in the variable name

### DIFF
--- a/lib/message_format/parser.rb
+++ b/lib/message_format/parser.rb
@@ -181,7 +181,7 @@ module MessageFormat
       id = ''
       while @index < @length
         char = @pattern[@index]
-        if char == '{' or char == '#'
+        if char == '{' or char == '#' || char == '.'
           raise_expected('argument id')
         end
         if char == '}' or char == ',' or is_whitespace(char)

--- a/lib/message_format/parser.rb
+++ b/lib/message_format/parser.rb
@@ -181,7 +181,7 @@ module MessageFormat
       id = ''
       while @index < @length
         char = @pattern[@index]
-        if char == '{' or char == '#' || char == '.'
+        if char == '{' or char == '#' or char == '.' or char == '(' or char == ')'
           raise_expected('argument id')
         end
         if char == '}' or char == ',' or is_whitespace(char)


### PR DESCRIPTION
We noticed that an ICU message looking like this is wrongly considered as a valid message:

```
{ count, plural, one {{results.length} result} other {{results.length} results} }
```

Note the use of the variable `{results.length}` instead of `{count}`, it could happen if the developer make a mistake while writing the ICU.

We checked and the same ICU triggers an error when parsed by the JS library [`@formatjs/icu-messageformat-parser`](https://github.com/formatjs/formatjs/tree/main/packages/icu-messageformat-parser)

We improved a bit the `parse_arg_id` method to also raise an exception when dot (`.`) is found in a variable.
I hope it made sense.

------------

Thank you for this gem that is really useful to us at Translation.io 🙂