### PR TITLE
fix some logic errors

### DIFF
--- a/lib/message_format.rb
+++ b/lib/message_format.rb
@@ -26,7 +26,7 @@ module MessageFormat
   class << self
 
     def new ( pattern, locale=nil, raise_on_missing_params: false )
-      MessageFormat.new(pattern, locale, raise_on_missing_params)
+      MessageFormat.new(pattern, locale, raise_on_missing_params: raise_on_missing_params)
     end
 
     def format_message ( pattern, args=nil, locale=nil, raise_on_missing_params: false )

--- a/lib/message_format/interpreter.rb
+++ b/lib/message_format/interpreter.rb
@@ -48,10 +48,11 @@ module MessageFormat
 
     def interpret ( elements )
       @missing_ids = []
-      interpret_subs(elements)
+      interpreted = interpret_subs(elements)
       if @raise_on_missing_params && !@missing_ids.empty?
         raise MissingParametersError.new('Missing parameters detected during interpretation', @missing_ids.compact)
       end
+      interpreted
     end
 
     def interpret_subs ( elements, parent=nil )


### PR DESCRIPTION
While running `bundle exec ruby benchmark.rb`, I ran into an error:

```
st-froydnj2:message-format-rb froydnj$ RBENV_VERSION=3.1 bundle exec ruby benchmark.rb
       user     system      total        real
parse simple message  0.623193   0.003719   0.626912 (  0.626966)
format simple message/Users/froydnj/stripe/message-format-rb/lib/message_format.rb:9:in `initialize': wrong number of arguments (given 3, expected 1..2) (ArgumentError)
	from /Users/froydnj/stripe/message-format-rb/lib/message_format.rb:29:in `new'
	from /Users/froydnj/stripe/message-format-rb/lib/message_format.rb:29:in `new'
	from benchmark.rb:15:in `block (2 levels) in <main>'
	from /Users/froydnj/.rbenv/versions/3.1.4/lib/ruby/3.1.0/benchmark.rb:296:in `measure'
	from /Users/froydnj/.rbenv/versions/3.1.4/lib/ruby/3.1.0/benchmark.rb:378:in `item'
	from benchmark.rb:14:in `block in <main>'
	from /Users/froydnj/.rbenv/versions/3.1.4/lib/ruby/3.1.0/benchmark.rb:176:in `benchmark'
	from /Users/froydnj/.rbenv/versions/3.1.4/lib/ruby/3.1.0/benchmark.rb:208:in `bm'
	from benchmark.rb:6:in `<main>'
```

It looks like `raise_on_missing_parameter` wasn't passed as a keyword argument in #11.  After fixing that, I ran into:

```
st-froydnj2:message-format-rb froydnj$ RBENV_VERSION=3.1 bundle exec ruby benchmark.rb
       user     system      total        real
parse simple message  0.625948   0.003741   0.629689 (  0.629774)
format simple message/Users/froydnj/stripe/message-format-rb/lib/message_format.rb:21:in `format': undefined method `call' for nil:NilClass (NoMethodError)

      @format.call(args)
             ^^^^^
	from benchmark.rb:17:in `block (3 levels) in <main>'
	from benchmark.rb:16:in `times'
	from benchmark.rb:16:in `block (2 levels) in <main>'
	from /Users/froydnj/.rbenv/versions/3.1.4/lib/ruby/3.1.0/benchmark.rb:296:in `measure'
	from /Users/froydnj/.rbenv/versions/3.1.4/lib/ruby/3.1.0/benchmark.rb:378:in `item'
	from benchmark.rb:14:in `block in <main>'
	from /Users/froydnj/.rbenv/versions/3.1.4/lib/ruby/3.1.0/benchmark.rb:176:in `benchmark'
	from /Users/froydnj/.rbenv/versions/3.1.4/lib/ruby/3.1.0/benchmark.rb:208:in `bm'
	from benchmark.rb:6:in `<main>'
```

This problem also comes from #11, which inadvertently changed the return value of `Interpreter#interpret`.  The second commit in this PR fixes that problem, after which the benchmarks run successfully.