### PR TITLE
make fewer string allocations while parsing

### DIFF
--- a/lib/message_format/parser.rb
+++ b/lib/message_format/parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 #
 # Parser
 #

--- a/lib/message_format/parser.rb
+++ b/lib/message_format/parser.rb
@@ -69,7 +69,7 @@ module MessageFormat
     def parse_text ( parent_type )
       is_hash_special = (parent_type == 'plural' or parent_type == 'selectordinal')
       is_arg_style = (parent_type == 'style')
-      text = ''
+      text = +''
       while @index < @length
         char = @pattern[@index]
         if (
@@ -83,7 +83,7 @@ module MessageFormat
           @index += 1
           char = @pattern[@index]
           if char == '\'' # double is always 1 '
-            text += char
+            text << char
             @index += 1
           elsif (
             # only when necessary
@@ -92,26 +92,26 @@ module MessageFormat
             (is_hash_special and char == '#') or
             (is_arg_style and is_whitespace(char))
           )
-            text += char
+            text << char
             while @index + 1 < @length
               @index += 1
               char = @pattern[@index]
               if @pattern.slice(@index, 2) == '\'\'' # double is always 1 '
-                text += char
+                text << char
                 @index += 1
               elsif char == '\'' # end of quoted
                 @index += 1
                 break
               else
-                text += char
+                text << char
               end
             end
           else # lone ' is just a '
-            text += '\''
+            text << '\''
             # already incremented
           end
         else
-          text += char
+          text << char
           @index += 1
         end
       end

--- a/lib/message_format/parser.rb
+++ b/lib/message_format/parser.rb
@@ -274,7 +274,7 @@ module MessageFormat
     end
 
     def parse_selector ()
-      selector = ''
+      selector = +''
       while @index < @length
         char = @pattern[@index]
         if char == '}' or char == ','
@@ -283,7 +283,7 @@ module MessageFormat
         if char == '{' or is_whitespace(char)
           break
         end
-        selector += char
+        selector << char
         @index += 1
       end
       if selector.empty?

--- a/lib/message_format/parser.rb
+++ b/lib/message_format/parser.rb
@@ -179,7 +179,7 @@ module MessageFormat
 
     def parse_arg_id ()
       skip_whitespace()
-      id = ''
+      id = +''
       while @index < @length
         char = @pattern[@index]
         if char == '{' or char == '#'
@@ -188,7 +188,7 @@ module MessageFormat
         if char == '}' or char == ',' or is_whitespace(char)
           break
         end
-        id += char
+        id << char
         @index += 1
       end
       if id.empty?


### PR DESCRIPTION
This series of patches reduces the number of string allocations that we do in two ways:

* Use `frozen_string_literal: true` to avoid repeatedly allocating strings everywhere; and
* Use `<<` rather than `+=` to append to strings, which avoids constructing a completely new string that we're just going to reassign to the relevant local variable.

The benchmark numbers for parsing are pretty positive, around a 20-25% speedup.  Before:

```
st-froydnj2:message-format-rb froydnj$ RBENV_VERSION=3.1 bundle exec ruby benchmark.rb
       user     system      total        real
parse simple message  0.629572   0.004259   0.633831 (  0.633984)
format simple message  0.007099   0.000021   0.007120 (  0.007174)
parse one arg message  0.737894   0.007335   0.745229 (  0.759587)
format one arg message  0.054347   0.000379   0.054726 (  0.054750)
parse complex message  9.670650   0.064200   9.734850 (  9.757098)
format complex message 10.288627   0.055089  10.343716 ( 10.347894)
```

After:

```
st-froydnj2:message-format-rb froydnj$ RBENV_VERSION=3.1 bundle exec ruby benchmark.rb
       user     system      total        real
parse simple message  0.491890   0.002199   0.494089 (  0.494625)
format simple message  0.007170   0.000030   0.007200 (  0.007200)
parse one arg message  0.543613   0.001446   0.545059 (  0.545091)
format one arg message  0.053703   0.000215   0.053918 (  0.053929)
parse complex message  7.012359   0.016199   7.028558 (  7.029539)
format complex message 10.504817   0.059677  10.564494 ( 10.578076)
```

Formatting is dominated by code outside of this gem's control, unfortunately.