### PR TITLE
Handle singe-apostrophe escapes

### DIFF
--- a/lib/message_format/parser.rb
+++ b/lib/message_format/parser.rb
@@ -94,6 +94,7 @@ module MessageFormat
             (is_arg_style and is_whitespace(char))
           )
             text << char
+            found_closing_quote = false
             while @index + 1 < @length
               @index += 1
               char = @pattern[@index]
@@ -102,10 +103,16 @@ module MessageFormat
                 @index += 1
               elsif char == '\'' # end of quoted
                 @index += 1
+                found_closing_quote = true
                 break
               else
                 text << char
               end
+            end
+            # If no closing quote was found, increment past the last character
+            # to avoid reprocessing it in the outer loop
+            if !found_closing_quote
+              @index += 1
             end
           else # lone ' is just a '
             text << '\''

--- a/spec/message_format_spec.rb
+++ b/spec/message_format_spec.rb
@@ -33,6 +33,13 @@ describe MessageFormat do
       expect(message).to eql('This isn\'t a {\'simple\'} \'string\'')
     end
 
+    it 'handles escaped single apostrophe escapes' do
+      pattern = 'Hello \'{literal}!'
+      message = MessageFormat.new(pattern, 'en-US').format()
+
+      expect(message).to eql('Hello {literal}!')
+    end
+
     it 'accepts arguments' do
       pattern = 'x{ arg }z'
       message = MessageFormat.new(pattern, 'en-US').format({ :arg => 'y' })


### PR DESCRIPTION
### What are you trying to accomplish?

Fixes #15 

### What approach did you choose and why?

Keep track of whether we found a second apostrophe to close an escape sequence.

### What should reviewers focus on?

🤷 I believe this is valid syntax, and therefore we should handle it.
If it weren't, we should instead raise.

https://format-message.github.io/icu-message-format-for-translators/editor.html accepts it.